### PR TITLE
Expo 45.0.0 issues fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# New Updates.
+# Expo 45.0.0 updates
 
 
 # Updated Recently, to make it work on new expo versions, and web
-# Expo 44 Supported Now!
+# Expo 45.0.0 Supported Now!
 # Android: (Development, Production)
 # iOS: (Development, Production)
 # Web: (Development, Production)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiction-expo-restart",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "This package helps restart react-native (Expo) app, development and production, both work",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
   "author": "Fiction Developers",
   "license": "ISC",
   "dependencies": {
-    "@unimodules/core": "^7.1.2",
-    "@unimodules/react-native-adapter": "^6.3.9",
     "expo-updates": "^0.4.1"
   }
 }


### PR DESCRIPTION
The previous version uses "unimodules" which threw errors in android builds, example is given below...

[stderr] Build file '/home/expo/workingdir/build/node_modules/@unimodules/core/android/build.gradle' line: 3
[stderr] * What went wrong:
[stderr] A problem occurred evaluating project ':unimodules-core'.
[stderr] > Plugin with id 'maven' not found.

I removed unnecessary dependency on unimodules. 